### PR TITLE
Update read model for kitchen (Chef) to get list of all food orders by tab

### DIFF
--- a/src/domain/tab/queries/kitchen.rs
+++ b/src/domain/tab/queries/kitchen.rs
@@ -1,46 +1,43 @@
 use async_trait::async_trait;
 use cqrs_es::View;
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 
 use crate::domain::tab::{aggregate::Tab, tab_id::TabId};
 
 #[async_trait]
 pub trait KitchenTodoListQuery: Sized {
-    async fn get_kitchen_todo_list(&self) -> Vec<KitchenTabView>;
+    async fn get_kitchen_todo_list(&self) -> Vec<TodoListGroup>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct KitchenTodoList {
-    inner: RwLock<Vec<KitchenTabView>>,
+    inner: Vec<TodoListGroup>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct KitchenTabView {
+pub struct TodoListGroup {
     pub(crate) tab_id: TabId,
-    pub(crate) food_items: Vec<KitchenTabItem>,
+    pub(crate) food_items: Vec<TodoListItem>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct KitchenTabItem {
+pub struct TodoListItem {
     pub(crate) menu_number: usize,
     pub(crate) description: String,
 }
 
 impl KitchenTodoList {
     pub fn new() -> Self {
-        Self {
-            inner: RwLock::new(Vec::new()),
-        }
+        Self { inner: Vec::new() }
     }
 }
 
-impl KitchenTabView {
+impl TodoListGroup {
     pub fn tab_id(&self) -> TabId {
         self.tab_id
     }
 
-    pub fn food_items(&self) -> Vec<KitchenTabItem> {
+    pub fn food_items(&self) -> Vec<TodoListItem> {
         let mut result = Vec::new();
         for item in self.food_items.iter() {
             result.push((*item).clone());
@@ -50,20 +47,28 @@ impl KitchenTabView {
     }
 }
 
-impl KitchenTabItem {
+impl TodoListItem {
     pub fn new(menu_number: usize, description: &str) -> Self {
         Self {
             menu_number,
             description: description.to_owned(),
         }
     }
+
+    pub fn menu_number(&self) -> usize {
+        self.menu_number
+    }
+
+    pub fn description(&self) -> String {
+        self.description.clone()
+    }
 }
 
-impl View<Tab> for KitchenTabView {
+impl View<Tab> for TodoListGroup {
     fn update(&mut self, event: &cqrs_es::EventEnvelope<Tab>) {
         match &event.payload {
             crate::domain::tab::event::TabEvent::FoodOrderPlaced { id, menu_item } => {
-                let tab_item = KitchenTabItem {
+                let tab_item = TodoListItem {
                     menu_number: menu_item.menu_number,
                     description: menu_item.description.clone(),
                 };
@@ -79,16 +84,56 @@ impl View<Tab> for KitchenTabView {
     }
 }
 
+impl View<Tab> for KitchenTodoList {
+    fn update(&mut self, event: &cqrs_es::EventEnvelope<Tab>) {
+        match &event.payload {
+            crate::domain::tab::event::TabEvent::FoodOrderPlaced { id, menu_item } => {
+                let mut todo_group = None;
+                for group in self.inner.iter_mut() {
+                    if group.tab_id == *id {
+                        todo_group = Some(group);
+                        break;
+                    }
+                }
+                let tab_item = TodoListItem {
+                    menu_number: menu_item.menu_number,
+                    description: menu_item.description.clone(),
+                };
+                match todo_group {
+                    Some(group) => group.food_items.push(tab_item),
+                    None => self.inner.push(TodoListGroup {
+                        tab_id: *id,
+                        food_items: vec![tab_item],
+                    }),
+                };
+            }
+            crate::domain::tab::event::TabEvent::FoodPrepared {
+                id: _,
+                menu_number: _,
+            } => {}
+            _ => {}
+        }
+    }
+}
+
 #[async_trait]
 impl KitchenTodoListQuery for KitchenTodoList {
-    async fn get_kitchen_todo_list(&self) -> Vec<KitchenTabView> {
-        let inner = self.inner.read().await;
-        let mut result = Vec::with_capacity(inner.len());
-        for item in inner.iter() {
+    async fn get_kitchen_todo_list(&self) -> Vec<TodoListGroup> {
+        // let inner = self.inner.read().await;
+        let mut result = Vec::with_capacity(self.inner.len());
+        for item in self.inner.iter() {
             result.push(item.clone())
         }
 
         result
+    }
+}
+
+impl std::ops::Deref for KitchenTodoList {
+    type Target = Vec<TodoListGroup>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 

--- a/src/domain/tab/queries/kitchen.rs
+++ b/src/domain/tab/queries/kitchen.rs
@@ -22,8 +22,8 @@ pub struct TodoListGroup {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct TodoListItem {
-    pub(crate) menu_number: usize,
-    pub(crate) description: String,
+    pub menu_number: usize,
+    pub description: String,
 }
 
 impl KitchenTodoList {
@@ -48,13 +48,6 @@ impl TodoListGroup {
 }
 
 impl TodoListItem {
-    pub fn new(menu_number: usize, description: &str) -> Self {
-        Self {
-            menu_number,
-            description: description.to_owned(),
-        }
-    }
-
     pub fn menu_number(&self) -> usize {
         self.menu_number
     }
@@ -64,25 +57,25 @@ impl TodoListItem {
     }
 }
 
-impl View<Tab> for TodoListGroup {
-    fn update(&mut self, event: &cqrs_es::EventEnvelope<Tab>) {
-        match &event.payload {
-            crate::domain::tab::event::TabEvent::FoodOrderPlaced { id, menu_item } => {
-                let tab_item = TodoListItem {
-                    menu_number: menu_item.menu_number,
-                    description: menu_item.description.clone(),
-                };
-                self.tab_id = *id;
-                self.food_items.push(tab_item);
-            }
-            crate::domain::tab::event::TabEvent::FoodPrepared {
-                id: _,
-                menu_number: _,
-            } => {}
-            _ => {}
-        }
-    }
-}
+// impl View<Tab> for TodoListGroup {
+//     fn update(&mut self, event: &cqrs_es::EventEnvelope<Tab>) {
+//         match &event.payload {
+//             crate::domain::tab::event::TabEvent::FoodOrderPlaced { id, menu_item } => {
+//                 let tab_item = TodoListItem {
+//                     menu_number: menu_item.menu_number,
+//                     description: menu_item.description.clone(),
+//                 };
+//                 self.tab_id = *id;
+//                 self.food_items.push(tab_item);
+//             }
+//             crate::domain::tab::event::TabEvent::FoodPrepared {
+//                 id: _,
+//                 menu_number: _,
+//             } => {}
+//             _ => {}
+//         }
+//     }
+// }
 
 impl View<Tab> for KitchenTodoList {
     fn update(&mut self, event: &cqrs_es::EventEnvelope<Tab>) {
@@ -119,7 +112,6 @@ impl View<Tab> for KitchenTodoList {
 #[async_trait]
 impl KitchenTodoListQuery for KitchenTodoList {
     async fn get_kitchen_todo_list(&self) -> Vec<TodoListGroup> {
-        // let inner = self.inner.read().await;
         let mut result = Vec::with_capacity(self.inner.len());
         for item in self.inner.iter() {
             result.push(item.clone())

--- a/src/domain/tab/queries/kitchen.rs
+++ b/src/domain/tab/queries/kitchen.rs
@@ -1,12 +1,18 @@
 use async_trait::async_trait;
 use cqrs_es::View;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use crate::domain::tab::{aggregate::Tab, tab_id::TabId};
 
 #[async_trait]
 pub trait KitchenTodoListQuery: Sized {
     async fn get_kitchen_todo_list(&self) -> Vec<KitchenTabView>;
+}
+
+#[derive(Debug, Default)]
+pub struct KitchenTodoList {
+    inner: RwLock<Vec<KitchenTabView>>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -19,6 +25,14 @@ pub struct KitchenTabView {
 pub struct KitchenTabItem {
     pub(crate) menu_number: usize,
     pub(crate) description: String,
+}
+
+impl KitchenTodoList {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Vec::new()),
+        }
+    }
 }
 
 impl KitchenTabView {
@@ -66,8 +80,23 @@ impl View<Tab> for KitchenTabView {
 }
 
 #[async_trait]
-impl KitchenTodoListQuery for KitchenTabView {
+impl KitchenTodoListQuery for KitchenTodoList {
     async fn get_kitchen_todo_list(&self) -> Vec<KitchenTabView> {
         todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::tab::queries::kitchen::KitchenTodoListQuery;
+
+    use super::KitchenTodoList;
+
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn given_new_KitchenTodoList_then_it_is_empty() {
+        let list = KitchenTodoList::new();
+
+        assert!(list.get_kitchen_todo_list().await.is_empty())
     }
 }

--- a/src/domain/tab/queries/kitchen.rs
+++ b/src/domain/tab/queries/kitchen.rs
@@ -15,7 +15,7 @@ pub struct KitchenTodoList {
     inner: RwLock<Vec<KitchenTabView>>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct KitchenTabView {
     pub(crate) tab_id: TabId,
     pub(crate) food_items: Vec<KitchenTabItem>,
@@ -82,7 +82,13 @@ impl View<Tab> for KitchenTabView {
 #[async_trait]
 impl KitchenTodoListQuery for KitchenTodoList {
     async fn get_kitchen_todo_list(&self) -> Vec<KitchenTabView> {
-        todo!()
+        let inner = self.inner.read().await;
+        let mut result = Vec::with_capacity(inner.len());
+        for item in inner.iter() {
+            result.push(item.clone())
+        }
+
+        result
     }
 }
 

--- a/src/shared_kernel/mod.rs
+++ b/src/shared_kernel/mod.rs
@@ -7,13 +7,14 @@ use cqrs_es::persist::ViewRepository;
 use postgres_es::PostgresViewRepository;
 use sqlx::{Pool, Postgres};
 
-use crate::domain::tab::{aggregate::Tab, queries::kitchen::KitchenTabView};
+use crate::domain::tab::aggregate::Tab;
+use crate::domain::tab::queries::kitchen::KitchenTodoList;
 
 pub type KitchenTabQuery =
-    GenericQuery<PostgresViewRepository<KitchenTabView, Tab>, KitchenTabView, Tab>;
+    GenericQuery<PostgresViewRepository<KitchenTodoList, Tab>, KitchenTodoList, Tab>;
 
 #[derive(Clone)]
-pub struct KitchenTabViewRepository(Arc<PostgresViewRepository<KitchenTabView, Tab>>);
+pub struct KitchenTabViewRepository(Arc<PostgresViewRepository<KitchenTodoList, Tab>>);
 
 impl KitchenTabViewRepository {
     pub fn new(pool: Pool<Postgres>) -> Self {
@@ -23,20 +24,20 @@ impl KitchenTabViewRepository {
         )))
     }
 
-    pub async fn load(&self, view_id: &str) -> Result<Option<KitchenTabView>, PersistenceError> {
+    pub async fn load(&self, view_id: &str) -> Result<Option<KitchenTodoList>, PersistenceError> {
         self.0.load(view_id).await
     }
 }
 
 impl std::ops::Deref for KitchenTabViewRepository {
-    type Target = Arc<PostgresViewRepository<KitchenTabView, Tab>>;
+    type Target = Arc<PostgresViewRepository<KitchenTodoList, Tab>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<KitchenTabViewRepository> for Arc<PostgresViewRepository<KitchenTabView, Tab>> {
+impl From<KitchenTabViewRepository> for Arc<PostgresViewRepository<KitchenTodoList, Tab>> {
     fn from(value: KitchenTabViewRepository) -> Self {
         value.deref().clone()
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -113,3 +113,77 @@ async fn given_new_tab_when_1_food_order_then_kitchen_list_view_shows_1_food_ord
     assert_eq!(actual[0].food_items()[0].menu_number(), 1);
     assert_eq!(actual[0].food_items()[0].description(), "Steak");
 }
+
+#[tokio::test]
+async fn given_tab_with_1_food_order_when_another_food_order_then_kitchen_list_view_shows_2_food_orders(
+) {
+    // Arrange
+    let db_name = Uuid::new_v4().to_string();
+    let params = ConnectionBuilder::new()
+        .with_credentials("postgres", Secret::new(String::from("password")))
+        .with_database(&db_name)
+        .build();
+    create_db(&params).await;
+    migrate_db(&params).await;
+    let pool = postgres_pool(&params).await;
+    let kitchen_tab_view_repo = KitchenTabViewRepository::new(pool.clone());
+    let services = TabServices {};
+    let tab_aggregate = cqrs_tab(pool, services, kitchen_tab_view_repo.clone());
+    let id = TabId::default();
+    let id_string = id.to_string();
+    tab_aggregate
+        .execute(
+            &id_string,
+            TabCommand::OpenTab {
+                id,
+                waiter_id: WaiterId::new(),
+                table: 1,
+            },
+        )
+        .await
+        .expect("failed to open tab");
+    tab_aggregate
+        .execute(
+            &id_string,
+            TabCommand::PlaceOrder {
+                order_items: vec![OrderItem {
+                    menu_number: 1,
+                    description: "Steak".into(),
+                    is_drink: false,
+                    price: Decimal::from(10),
+                }],
+            },
+        )
+        .await
+        .expect("failed to order 1st food");
+
+    // Act
+    tab_aggregate
+        .execute(
+            &id_string,
+            TabCommand::PlaceOrder {
+                order_items: vec![OrderItem {
+                    menu_number: 1,
+                    description: "Steak".into(),
+                    is_drink: false,
+                    price: Decimal::from(10),
+                }],
+            },
+        )
+        .await
+        .expect("failed to order 2nd food");
+
+    // Assert
+    let actual = kitchen_tab_view_repo
+        .load(&id_string)
+        .await
+        .expect("failed to load the kitchen tab view")
+        .unwrap();
+    assert_eq!(actual.len(), 1);
+    assert_eq!(actual[0].tab_id(), id);
+    assert_eq!(actual[0].food_items().len(), 2);
+    assert_eq!(actual[0].food_items()[0].menu_number(), 1);
+    assert_eq!(actual[0].food_items()[0].description(), "Steak");
+    assert_eq!(actual[0].food_items()[1].menu_number(), 1);
+    assert_eq!(actual[0].food_items()[1].description(), "Steak");
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,10 @@
 use cafe_tab::{
-    domain::tab::{command::TabCommand, services::TabServices, tab_id::TabId, waiter_id::WaiterId},
+    domain::tab::{
+        command::{OrderItem, TabCommand},
+        services::TabServices,
+        tab_id::TabId,
+        waiter_id::WaiterId,
+    },
     infrasctructure::{
         persistence::context::{
             connection_parameters::ConnectionBuilder,
@@ -9,11 +14,12 @@ use cafe_tab::{
     },
     shared_kernel::KitchenTabViewRepository,
 };
+use rust_decimal::Decimal;
 use secrecy::Secret;
 use uuid::Uuid;
 
 #[tokio::test]
-async fn initially_tab_is_empty() {
+async fn initially_kitchen_todo_list_is_empty() {
     // Arrange
     let db_name = Uuid::new_v4().to_string();
     let params = ConnectionBuilder::new()
@@ -48,6 +54,62 @@ async fn initially_tab_is_empty() {
         .await
         .expect("failed to load the kitchen tab view")
         .unwrap();
-    assert_eq!(actual.tab_id(), id);
-    assert_eq!(actual.food_items().len(), 0);
+    assert_eq!(actual.len(), 0);
+}
+
+#[tokio::test]
+async fn given_new_tab_when_1_food_order_then_kitchen_list_view_shows_1_food_order() {
+    // Arrange
+    let db_name = Uuid::new_v4().to_string();
+    let params = ConnectionBuilder::new()
+        .with_credentials("postgres", Secret::new(String::from("password")))
+        .with_database(&db_name)
+        .build();
+    create_db(&params).await;
+    migrate_db(&params).await;
+    let pool = postgres_pool(&params).await;
+    let kitchen_tab_view_repo = KitchenTabViewRepository::new(pool.clone());
+    let services = TabServices {};
+    let tab_aggregate = cqrs_tab(pool, services, kitchen_tab_view_repo.clone());
+    let id = TabId::default();
+    let id_string = id.to_string();
+    tab_aggregate
+        .execute(
+            &id_string,
+            TabCommand::OpenTab {
+                id,
+                waiter_id: WaiterId::new(),
+                table: 1,
+            },
+        )
+        .await
+        .expect("failed to open tab");
+
+    // Act
+    tab_aggregate
+        .execute(
+            &id_string,
+            TabCommand::PlaceOrder {
+                order_items: vec![OrderItem {
+                    menu_number: 1,
+                    description: "Steak".into(),
+                    is_drink: false,
+                    price: Decimal::from(10),
+                }],
+            },
+        )
+        .await
+        .expect("failed to order food");
+
+    // Assert
+    let actual = kitchen_tab_view_repo
+        .load(&id_string)
+        .await
+        .expect("failed to load the kitchen tab view")
+        .unwrap();
+    assert_eq!(actual.len(), 1);
+    assert_eq!(actual[0].tab_id(), id);
+    assert_eq!(actual[0].food_items().len(), 1);
+    assert_eq!(actual[0].food_items()[0].menu_number(), 1);
+    assert_eq!(actual[0].food_items()[0].description(), "Steak");
 }


### PR DESCRIPTION
- the proper abstraction is the KitchenTodoList and not KitchenTodoGroup
- KitchenTodoList is a list of structures containing the Tab ID and its food orders
- not sure how to handle locking for now